### PR TITLE
- Fixed semaphore timeout issue which was freezing the full applicati…

### DIFF
--- a/Classes/Core/Utils/MMUtils.swift
+++ b/Classes/Core/Utils/MMUtils.swift
@@ -612,7 +612,7 @@ extension MMApplication {
 			}
 		}
 
-		semasphore.wait()
+        let _ = semasphore.wait(timeout: .now() + 5)
 		return notificationSettings?.alertSetting == UNNotificationSetting.enabled ||
 			notificationSettings?.badgeSetting == UNNotificationSetting.enabled ||
 			notificationSettings?.soundSetting == UNNotificationSetting.enabled


### PR DESCRIPTION
We are using your SDK version `9.2.4` and our users where facing the issue that the application was getting stuck when they were try to enable the push notification. Therefore, we have tried to identify the issue and we have found that semaphore blocking while checking the notification settings is creating the issue. So, we have fixed that issue so please review this asap and merge it.